### PR TITLE
Add Claycode Finder

### DIFF
--- a/scanner/app/src/main/java/com/claycode/scanner/topology_analysis/ClaycodeFinder.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/topology_analysis/ClaycodeFinder.kt
@@ -1,0 +1,55 @@
+package com.claycode.scanner.topology_analysis
+
+import com.claycode.scanner.data_structures.Tree
+
+/**
+ * Finds potential Claycode in a given topology tree.
+ */
+class ClaycodeFinder {
+    companion object {
+        /**
+         *  The outer white may mix with some part of the background,
+         *  resulting in a shape with multiple children.
+         *  Therefore, we do not account for it.
+         *
+         *  The tower height represents for how many consecutive generations nodes have been only-children.
+         *  A node that has siblings has a tower-height of zero.
+         *  If a node has tower-height `h`, and it has only one child, that child has tower height `h+1`.
+         */
+
+        // The tower-height of Claycode roots. Depends on the Claycode's frame.
+        val CLAYCODE_ROOT_TOWER_HEIGHT = 3
+        fun findPotentialClaycodeRoots(topologyTree: Tree) : List<Tree> {
+            return findAllNodesWithTowerHeightGreaterThan(topologyTree, CLAYCODE_ROOT_TOWER_HEIGHT)
+        }
+
+        /**
+         * Given a tree and a target tower height, returns all the
+         * nodes in the tree that have at least the given tower height.
+         */
+        fun findAllNodesWithTowerHeightGreaterThan(treeRoot: Tree, targetTowerHeight: Int) : List<Tree> {
+            val result : MutableList<Tree> = mutableListOf()
+
+            // We execute an iterative BFS,
+            // Keeping track of the current tower-height
+            val stack = mutableListOf(Pair(treeRoot, 0))
+            while (stack.isNotEmpty()) {
+                val (currentNode, currentTowerHeight) = stack.removeAt(0)
+
+                // Process the current node
+                if (currentTowerHeight >= targetTowerHeight) {
+                    result.add(currentNode)
+                }
+
+                val hasOnlyOneChild = currentNode.children.size == 1
+                val nextTowerHeight = if (hasOnlyOneChild) currentTowerHeight + 1 else 0
+                for (childNode in currentNode.children) {
+                    stack.add(Pair(childNode, nextTowerHeight))
+                }
+            }
+
+            return result
+        }
+
+    }
+}

--- a/scanner/app/src/test/java/com/claycode/scanner/ClaycodeFinderUnitTest.kt
+++ b/scanner/app/src/test/java/com/claycode/scanner/ClaycodeFinderUnitTest.kt
@@ -1,0 +1,103 @@
+package com.claycode.scanner
+
+import com.claycode.scanner.data_structures.Tree
+import com.claycode.scanner.topology_analysis.ClaycodeFinder
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ClaycodeFinderUnitTest {
+    // All nodes have a tower-height <= 3
+    // Each tree has at least a node with tower-height >=1
+    private val testTrees1 = listOf(
+        "(())",
+        "(()(()))",
+        "(((())))",
+        "(((()))(()))",
+    )
+
+    @Test
+    fun findAllNodesWithTowerHeightOf_Basic() {
+        // Define the function in a shorter form
+        val f: (String, Int) -> List<Tree> = { treeStr, height ->
+            ClaycodeFinder.findAllNodesWithTowerHeightGreaterThan(
+                Tree.fromString(treeStr), height
+            )
+        }
+
+        // Broad basic tests
+        for (treeStr in testTrees1) {
+            assertEquals(emptyList<Tree>(), f(treeStr, 6))
+            assertEquals(emptyList<Tree>(), f(treeStr, 5))
+            assertEquals(emptyList<Tree>(), f(treeStr, 4))
+            assertTrue(f(treeStr, 1).isNotEmpty())
+        }
+
+
+        // Helper function to turn found trees into a sorted
+        // array of string representations of the tree.
+        // This makes it easier to build tests.
+        val resf: (List<Tree>) -> Array<String> = {
+            it.map { tree -> tree.toString() }
+                .sorted()
+                .toTypedArray()
+        }
+
+        // NOTE: in case the test fails, Android Studio seems to have
+        // a weird behavior by which it changes the visualisation of the strings, e.g.,
+        // assertArrayEquals(arrayOf("(())"), arrayOf("()"))
+        // Gives the error:
+        //    arrays first differed at element [0];
+        //    Expected :([()])
+        //    Actual   :([])
+        // It is replacing the outer round brackets with square brackets.
+
+        // let us first test a simple tower
+        //        012345
+        val t1 = "(((((())))))"
+        assertArrayEquals(arrayOf("()"), resf(f(t1, 5)))
+        assertArrayEquals(arrayOf("(())", "()"), resf(f(t1, 4)))
+        assertArrayEquals(arrayOf("((()))", "(())", "()"), resf(f(t1, 3)))
+        assertArrayEquals(arrayOf("(((())))", "((()))", "(())", "()"), resf(f(t1, 2)))
+        assertArrayEquals(arrayOf("((((()))))", "(((())))", "((()))", "(())", "()"), resf(f(t1, 1)))
+        assertArrayEquals(
+            arrayOf("(((((())))))", "((((()))))", "(((())))", "((()))", "(())", "()"),
+            resf(f(t1, 0))
+        )
+
+        // Next, a tower with a reset in the middle
+        // tower: 0120 012
+        val t2 = "(((()((())))))"
+        assertArrayEquals(arrayOf(), resf(f(t2, 5)))
+        assertArrayEquals(arrayOf(), resf(f(t2, 4)))
+        assertArrayEquals(arrayOf(), resf(f(t2, 3)))
+        assertArrayEquals(arrayOf("(()((())))", "()"), resf(f(t2, 2)))
+        assertArrayEquals(
+            arrayOf(
+                "((()((()))))", "(()((())))",
+                "(())", "()"
+            ), resf(f(t2, 1))
+        )
+
+        // Next, a bi-forking tower with a reset in the middle
+        // Note, it's the previous two tests together
+        // tower: 0123456      0120 012
+        val t3 = "((((((())))))(((()((()))))))"
+        // Only left branch has these, same as t1
+        assertArrayEquals(arrayOf("()"), resf(f(t3, 5)))
+        assertArrayEquals(arrayOf("(())", "()"), resf(f(t3, 4)))
+        assertArrayEquals(arrayOf("((()))", "(())", "()"), resf(f(t3, 3)))
+        // Now, merge t1 and t2's. Mixed as they must be sorted.
+        assertArrayEquals(arrayOf("(((())))", "((()))","(()((())))", "(())", "()", "()"), resf(f(t3, 2)))
+
+        // A tree with a single 2-tower hidden in the middle
+        // tower: 000 0 00 012     00 0 00 0
+        val t4 = "((()()(()((()))))(()()(()())))"
+        assertArrayEquals(arrayOf(), resf(f(t4, 5)))
+        assertArrayEquals(arrayOf(), resf(f(t4, 4)))
+        assertArrayEquals(arrayOf(), resf(f(t4, 3)))
+        assertArrayEquals(arrayOf("()"), resf(f(t4, 2)))
+
+    }
+}


### PR DESCRIPTION
Add Claycode finder, an algorithm that, given a tree, finds all nodes that have a tower-height of at least 3.

The tower height represents for how many consecutive generations nodes have been only-children.
  -  A node that has siblings has a tower-height of zero.
  -  If a node has tower-height `h`, and it has only one child, that child has tower height `h+1`.

Add unit tests. Unit tests are a bit nasty for this function, so I created some helper functions to visualise them 

No chat GPT used (almost)
