### PR TITLE
Add continuous image analysis

### DIFF
--- a/scanner/app/src/main/java/com/claycode/scanner/MainActivity.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/MainActivity.kt
@@ -4,16 +4,11 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.Matrix
 import android.os.Bundle
-import android.util.Log
 import android.util.Size
-import android.view.Surface
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.camera.core.ImageAnalysis
-import androidx.camera.core.ImageCapture
-import androidx.camera.core.ImageCaptureException
-import androidx.camera.core.ImageProxy
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
 import androidx.camera.view.PreviewView
@@ -32,7 +27,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +43,6 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import androidx.lifecycle.MutableLiveData
 import com.claycode.scanner.ui.theme.ClaycodeScannerTheme
 
 const val TARGET_SIZE_PCT = 0.9f;


### PR DESCRIPTION
This PR adds the following:
* Continuous image analysis running in the background
* Bitmap is rotated only when a claycode is scanned successfully (i.e. we are now analysing rotated images)

The analysis is disabled when results are shown on the screen