### PR TITLE
Add private domain demos, support coloured claycodes

### DIFF
--- a/scanner/app/src/main/cpp/topology_extractor.cpp
+++ b/scanner/app/src/main/cpp/topology_extractor.cpp
@@ -93,13 +93,8 @@ Java_com_claycode_scanner_ClaycodeDecoder_00024Companion_extractTouchGraph(
      *****************/
     cv::Mat img = prepareInputImage(env, bitmap, info, pixels, left, top, width, height);
 
-    // Convert to grayscale, threshold
+    // Convert to grayscale
     cv::cvtColor(img, img, cv::COLOR_BGR2GRAY);
-    cv::threshold(img, img, 127, 255, cv::THRESH_BINARY);
-
-    // Turn the gray image back to BGR. Note that this is wasteful at the moment, but in the future
-    // we want to support coloured Claycodes. Hence, we want to build the rest of the code for BGR images.
-    cv::cvtColor(img, img, cv::COLOR_GRAY2BGR);
 
     logRelativeTime("OpenCV", startTime);
 

--- a/scanner/app/src/main/java/com/claycode/scanner/ClaycodeDecoder.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/ClaycodeDecoder.kt
@@ -66,7 +66,29 @@ class ClaycodeDecoder {
             val potentialClaycodeTrees = ClaycodeFinder.findPotentialClaycodeRoots(topologyTree)
             logRelativeTime("Find Potential Claycodes", startTime);
 
+            // Log longest potential Claycode
+            val longest = potentialClaycodeTrees.maxByOrNull { it.toString().length }
+            if(longest != null) {
+                Log.i("Trees", longest.toString())
+            }
+
             var results: Array<String> = emptyArray()
+
+            // 1 - Check for the private domain
+            for (tree in potentialClaycodeTrees) {
+                when (tree.toString()) {
+                    // NOTE: This is not the correct way to do it -- this is temporary.
+                    // We should check for equivalence in a way that's not dependent on the tree ordering
+                    "((((((())()()()()()()(()()()())(()))))))" -> {
+                        results += "Woof \uD83D\uDC36"
+                    }
+                    "((((()()())()()()()()()()()()()()()()()()()()()()()()()())))" -> {
+                        results += "\uD83C\uDFB5 I am not just a Spotify Code... \uD83C\uDFB5"
+                    }
+                }
+            }
+
+            // 2 - Check for the public domain
             for (tree in potentialClaycodeTrees) {
                 val bits = BitTreeConverter.treeToBits(tree)
                 val decoded = BitsValidator.getValidatedBitString(bits)
@@ -82,7 +104,7 @@ class ClaycodeDecoder {
                 out += "$r "
             }
 
-            return Triple(potentialClaycodeTrees.size,results.size, out)
+            return Triple(potentialClaycodeTrees.size, results.size, out)
         }
     }
 }


### PR DESCRIPTION
Add two hard-coded demos, remove thresholding from pipeline (it is not needed) unlocking colored Claycodes!
