### PR TITLE
Change Claycode detection mechanism

### DIFF
--- a/scanner/app/src/main/java/com/claycode/scanner/ClaycodeDecoder.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/ClaycodeDecoder.kt
@@ -79,10 +79,10 @@ class ClaycodeDecoder {
                 when (tree.toString()) {
                     // NOTE: This is not the correct way to do it -- this is temporary.
                     // We should check for equivalence in a way that's not dependent on the tree ordering
-                    "((((((())()()()()()()(()()()())(()))))))" -> {
+                    "((())()()()()()()(()()()())(()))" -> {
                         results += "Woof \uD83D\uDC36"
                     }
-                    "((((()()())()()()()()()()()()()()()()()()()()()()()()()())))" -> {
+                    "((()()())()()()()()()()()()()()()()()()()()()()()()()())" -> {
                         results += "\uD83C\uDFB5 I am not just a Spotify Code... \uD83C\uDFB5"
                     }
                 }

--- a/scanner/app/src/main/java/com/claycode/scanner/topology_analysis/ClaycodeFinder.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/topology_analysis/ClaycodeFinder.kt
@@ -8,19 +8,52 @@ import com.claycode.scanner.data_structures.Tree
 class ClaycodeFinder {
     companion object {
         /**
-         *  The outer white may mix with some part of the background,
-         *  resulting in a shape with multiple children.
-         *  Therefore, we do not account for it.
+         *  We can identify potential Claycodes by either looking for *towers* or for nodes with at least N descendants.
          *
+         *  Tower approach:
+         *  The outer white may mix with some part of the background, resulting in a shape with multiple children.
+         *  Therefore, we do not account for it.
          *  The tower height represents for how many consecutive generations nodes have been only-children.
          *  A node that has siblings has a tower-height of zero.
          *  If a node has tower-height `h`, and it has only one child, that child has tower height `h+1`.
+         *
+         *  Descendants approach:
+         *  This approach is more straightforward and can lead to more false positives. We simply return all nodes with
+         *  at least N descendants. The idea stems from the fact that random images do not lead to complex topologies.
          */
 
         // The tower-height of Claycode roots. Depends on the Claycode's frame.
         val CLAYCODE_ROOT_TOWER_HEIGHT = 3
+        // The minimum number of descendants necessary for a node to be considered a potential Claycode root.
+        val CLAYCODE_ROOT_MIN_DESCENDANTS = 10
         fun findPotentialClaycodeRoots(topologyTree: Tree) : List<Tree> {
-            return findAllNodesWithTowerHeightGreaterThan(topologyTree, CLAYCODE_ROOT_TOWER_HEIGHT)
+            // return findAllNodesWithTowerHeightGreaterThan(topologyTree, CLAYCODE_ROOT_TOWER_HEIGHT)
+            return findNodesWithAtLeastNDescendants(topologyTree, CLAYCODE_ROOT_MIN_DESCENDANTS)
+        }
+
+        /**
+         * Given a tree and a target number of nodes N, finds all the
+         * nodes with at least N descendants.
+         * A leaf has 1 descendant, which is itself.
+         */
+        fun findNodesWithAtLeastNDescendants(root: Tree, N: Int): List<Tree> {
+            val result = mutableListOf<Tree>()
+
+            // Helper function to count descendants
+            fun countDescendants(node: Tree): Int {
+                var count = 1
+                for (child in node.children) {
+                    count += countDescendants(child)
+                }
+
+                if (count >= N) {
+                    result.add(node)
+                }
+                return count
+            }
+
+            countDescendants(root)
+            return result
         }
 
         /**

--- a/scanner/app/src/test/java/com/claycode/scanner/ClaycodeFinderUnitTest.kt
+++ b/scanner/app/src/test/java/com/claycode/scanner/ClaycodeFinderUnitTest.kt
@@ -2,6 +2,7 @@ package com.claycode.scanner
 
 import com.claycode.scanner.data_structures.Tree
 import com.claycode.scanner.topology_analysis.ClaycodeFinder
+import com.claycode.scanner.topology_analysis.ClaycodeFinder.Companion.findNodesWithAtLeastNDescendants
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -99,5 +100,49 @@ class ClaycodeFinderUnitTest {
         assertArrayEquals(arrayOf(), resf(f(t4, 3)))
         assertArrayEquals(arrayOf("()"), resf(f(t4, 2)))
 
+    }
+
+
+    @Test
+    fun testFindNodesWithAtLeastNDescendants_Basic() {
+        val f: (String, Int) -> List<Tree> = { treeStr, nDescendants ->
+            findNodesWithAtLeastNDescendants(Tree.fromString(treeStr), nDescendants)
+        }
+
+        // Initial sparse tests
+        val testTrees1 = listOf("(()(()))", "((()))", "(((())))", "((()()))")
+        for (treeStr in testTrees1) {
+            assertEquals(emptyList<Tree>(), f(treeStr, 6))
+            assertEquals(emptyList<Tree>(), f(treeStr, 5))
+            assertTrue(f(treeStr, 1).isNotEmpty())
+        }
+
+        // Helper function to get sorted results, as we do not require the function
+        // to return results in a specific way
+        val resf: (List<Tree>) -> Array<String> = {
+            it.map { tree -> tree.toString() }
+                .sorted()
+                .toTypedArray()
+        }
+
+        val t1 = "()"
+        assertArrayEquals(arrayOf("()"), resf(f(t1, 1)))
+        assertEquals(emptyList<Tree>(), f(t1, 2))
+
+        val t2 = "(((((())))))" // tower of 6
+        assertEquals(emptyList<Tree>(), f(t2, 7))
+        assertArrayEquals(arrayOf("(((((())))))"), resf(f(t2, 6)))
+        assertArrayEquals(arrayOf("(((((())))))", "((((()))))"), resf(f(t2, 5)))
+        assertArrayEquals(arrayOf("(((((())))))", "((((()))))", "(((())))"), resf(f(t2, 4)))
+
+        val t3 = "(((()()()()())))"  // tower of 3, with 5 leaves at the end
+        assertEquals(emptyList<Tree>(), f(t3, 9))
+        assertArrayEquals(arrayOf("(((()()()()())))", "((()()()()()))", "(()()()()())"), resf(f(t3, 5)))
+
+        val t4 = "((()())(()()))"  // Fully balanced binary tree with height 3
+        assertArrayEquals(arrayOf("((()())(()()))", "(()())", "(()())", "()","()","()","()"), resf(f(t4, 1)))
+        assertArrayEquals(arrayOf("((()())(()()))", "(()())", "(()())"), resf(f(t4, 2)))
+        assertArrayEquals(arrayOf("((()())(()()))", "(()())", "(()())"), resf(f(t4, 3)))
+        assertArrayEquals(arrayOf("((()())(()()))"), resf(f(t4, 4)))
     }
 }


### PR DESCRIPTION
Change detection mechanism to detect all nodes with at least 10 descendants.

This increases the number of false positives that must be filtered by CRC, but greatly improves detection probability.


Before:
![before](https://github.com/marcomaida/claycode/assets/28363981/56cc9a5a-340c-4dc4-bde2-b6a5e22d0745)

After:
![after](https://github.com/marcomaida/claycode/assets/28363981/13090db3-03f7-4924-890a-ba3764853617)


![photo_2024-06-30 14 23 01 (1)](https://github.com/marcomaida/claycode/assets/28363981/5b25e81d-ca57-406a-96bf-c9da16136d99)
![photo_2024-06-30 14 23 01](https://github.com/marcomaida/claycode/assets/28363981/4da8c6ed-99f6-4151-aadf-eca915cf7b77)
