### PR TITLE
Add fps counter

### DIFF
--- a/scanner/app/src/main/java/com/claycode/scanner/FpsCounter.kt
+++ b/scanner/app/src/main/java/com/claycode/scanner/FpsCounter.kt
@@ -1,0 +1,20 @@
+package com.claycode.scanner
+
+import java.util.ArrayDeque
+
+class FpsCounter(private val maxSamples : Int) {
+    private var ringBuffer = ArrayDeque<Long>()
+    private var runningSum = 0.0
+
+    public fun addSample(elapsedTimeMs: Long) : Double {
+        runningSum += elapsedTimeMs
+        ringBuffer.addFirst(elapsedTimeMs)
+        if (ringBuffer.size == maxSamples)
+        {
+            runningSum -= ringBuffer.removeLast()
+        }
+
+        val avg = runningSum/ringBuffer.size
+        return 1/(avg/1000)
+    }
+}


### PR DESCRIPTION
![image](https://github.com/marcomaida/claycode/assets/26961317/4adc0f79-b8f1-4e32-91a6-c813e4f8f8e7)

Adds an FPS counter to the MainActivity for real-time frame rate analysis.

### What changed?

- Introduced `FpsCounter` class to calculate FPS in `FpsCounter.kt`
- Integrated FPS counter into `MainActivity`.

### How to test?

1. Open the app.
2. Observe the FPS counter at the top-right corner of the screen.

### Why make this change?

Enhancing the app with real-time performance metrics helps debug and improve the application's efficiency.

---

