### PR TITLE
Add fixed-topology generator

### DIFF
--- a/generator/pages/scene_fragment.html
+++ b/generator/pages/scene_fragment.html
@@ -25,6 +25,11 @@
     <div id="footerDivTreeGen" class="tree-gen-footer-div">
 
       <div class="tree-gen-label">
+        Tree Topology:
+        <input id="inputTreeTopology" value="" class="tree_gen_val_long" />
+      </div>
+
+      <div class="tree-gen-label">
         Num Fragments:
         <input type="number" id="inputNumFragments" maxlength="4" value="4" class="tree_gen_val" />
       </div>

--- a/generator/pages/style.css
+++ b/generator/pages/style.css
@@ -125,7 +125,7 @@ a {
 
 .tree-gen-label {
   font-size: 15pt;
-  text-align: right;
+  text-align: middle;
   color: whitesmoke;
 }
 
@@ -134,6 +134,13 @@ a {
   vertical-align: middle;
   text-align: left;
   width: 50pt;
+}
+
+.tree_gen_val_long {
+  font-size: 15pt;
+  vertical-align: middle;
+  text-align: left;
+  width: 300pt;
 }
 
 .change_shape_div {

--- a/generator/scenes/scene_fragment.js
+++ b/generator/scenes/scene_fragment.js
@@ -10,6 +10,7 @@ import { TreeNode } from "../tree/tree_node.js";
 
 const app = initPIXI();
 const infoText = initInfoText();
+const inputTreeTopology = document.getElementById("inputTreeTopology");
 const inputNumFragments = document.getElementById("inputNumFragments");
 const inputNumNodes = document.getElementById("inputNumNodes");
 
@@ -81,8 +82,18 @@ function generateRandomTree(N) {
 }
 
 function polygonView() {
-  let current_tree = generateRandomTree(inputNumNodes.value);
-  current_tree = duplicateTreeNTimes(current_tree, inputNumFragments.value)
+
+  let current_tree = Tree.fromString(inputTreeTopology.value)
+  if (!current_tree) {
+    inputTreeTopology.value = generateRandomTree(inputNumNodes.value).toString();
+    current_tree = Tree.fromString(inputTreeTopology.value)
+    if (!current_tree) {
+      throw `current tree cannot be null after the tree was generated`;
+    }
+  }
+
+  clearDrawing();
+  current_tree = duplicateTreeNTimes(current_tree, inputNumFragments.value);
 
   let infoSuffix = ``;
 
@@ -172,8 +183,13 @@ document.addEventListener("keydown", function (event) {
 });
 
 polygonView();
+
+inputTreeTopology.addEventListener("input", () => debounce(polygonView, 100));
 inputNumFragments.addEventListener("input", () => debounce(polygonView, 100));
-inputNumNodes.addEventListener("input", () => debounce(polygonView, 100));
+inputNumNodes.addEventListener("input", () => {
+  inputTreeTopology.value = ""
+  debounce(polygonView, 100);
+});
 window.onresize = function () {
   debounce(polygonView, 50);
 };

--- a/generator/scenes/scene_test.js
+++ b/generator/scenes/scene_test.js
@@ -4,4 +4,5 @@ import {} from "../test/test_vector.js";
 import {} from "../test/test_geometry.js";
 import {} from "../test/test_polygon_partition.js";
 import {} from "../test/test_conversion.js";
+import {} from "../test/test_tree.js";
 test_heading("OK!");

--- a/generator/test/test_tree.js
+++ b/generator/test/test_tree.js
@@ -1,0 +1,63 @@
+import { Tree } from "../tree/tree.js";
+import { TreeNode } from "../tree/tree_node.js";
+import { assert_eq, assert_true, test_section, test_heading } from "./test_utils.js";
+
+try {
+    test_heading("Tree");
+
+    test_section("Tree.toString");
+    {
+        let root = new TreeNode();
+        root.children = [new TreeNode(), new TreeNode(), new TreeNode()];
+        root.children[0].children = [new TreeNode(), new TreeNode()];
+        root.children[2].children = [new TreeNode()];
+        let tree = new Tree(root)
+        assert_eq(tree.toString(), '((()())()(()))');
+    }
+
+    test_section("Tree.fromString");
+    {
+        let tree = Tree.fromString('(()(())(()()))')
+        assert_eq(tree.root.children.length, 3);
+        assert_true(tree.root.children[0].isLeaf()); // First child
+        assert_eq(tree.root.children[1].children.length, 1);  // Second child
+        assert_true(tree.root.children[1].children[0].isLeaf());
+        assert_eq(tree.root.children[2].children.length, 2);  // Third child
+        assert_true(tree.root.children[2].children[0].isLeaf());
+        assert_true(tree.root.children[2].children[1].isLeaf());
+    }
+
+    test_section("Tree.toString(Tree.fromString)");
+    {
+        let t = `()`;
+        assert_eq(TreeNode.fromString(t).toString(), t);
+    }
+    {
+        let t = `(()())`;
+        assert_eq(TreeNode.fromString(t).toString(), t);
+    }
+    {
+        let t = `((())(()())())`;
+        assert_eq(TreeNode.fromString(t).toString(), t);
+    }
+    {
+        let t = `(()((()))()(())(()(()())))`;
+        assert_eq(TreeNode.fromString(t).toString(), t);
+    }
+
+    test_section("Tree.fromString, invalid inputs");
+    {
+        assert_eq(TreeNode.fromString(')'), null)
+        assert_eq(TreeNode.fromString('())'), null)
+        assert_eq(TreeNode.fromString('((())))'), null)
+        assert_eq(TreeNode.fromString('()a'), null)
+        assert_eq(TreeNode.fromString('a'), null)
+        assert_eq(TreeNode.fromString('(1)'), null)
+        assert_eq(TreeNode.fromString(''), null)
+    }
+
+
+
+} catch (error) {
+    console.error(`TEST FAILED: ${error}`);
+}

--- a/generator/tree/tree.js
+++ b/generator/tree/tree.js
@@ -1,4 +1,4 @@
-const SEED_COLLIDER_SEGMENTS = 10;
+import { TreeNode } from "./tree_node.js";
 
 export class Tree {
   constructor(root) {
@@ -8,6 +8,18 @@ export class Tree {
 
     this.initialize_nodes(this.root, "X", 0);
     this.compute_weights(1);
+  }
+
+  toString() {
+    return this.root.toString()
+  }
+
+  static fromString(str) {
+    let root = TreeNode.fromString(str)
+    if (root)
+      return new Tree(root)
+    else
+      return null
   }
 
   /**

--- a/generator/tree/tree_node.js
+++ b/generator/tree/tree_node.js
@@ -38,4 +38,53 @@ export class TreeNode {
   isLeaf() {
     return this.children.length === 0;
   }
+
+  toString() {
+    let result = '';
+
+    function serialize(node) {
+      if (!node) return;
+
+      result += '(';
+      for (const child of node.children) {
+        serialize(child);
+      }
+      result += ')';
+    }
+
+    serialize(this);
+    return result;
+  }
+
+  static fromString(str) {
+    if (!str || str[0] !== '(' || str[str.length - 1] !== ')') return null;
+
+    let stack = [];
+    let root = null;
+    let currentNode = null;
+
+    for (let char of str) {
+      if (char === '(') {
+        let newNode = new TreeNode();
+        if (currentNode) {
+          currentNode.children.push(newNode);
+          newNode.father = currentNode;
+        } else {
+          root = newNode;
+        }
+        stack.push(newNode);
+        currentNode = newNode;
+      } else if (char === ')') {
+        if (!stack.length) {
+          return null; // Unbalanced brackets
+        }
+        stack.pop();
+        currentNode = stack.length ? stack[stack.length - 1] : null;
+      } else {
+        return null; // Invalid character in string
+      }
+    }
+
+    return root;
+  }
 }


### PR DESCRIPTION
We need a way to be able to consistently create a Claycode given a topology

- Add the functions from and to string for Tree, in JS
- Modify the fragment scene to incorporate a "topology" field. This way, a new topology can be generated, but also an existing one can be inputted. Topologies are represented with brackets, e.g. `(((((())(((())))(())))((()((())))())()()(()))()(())())`

<img width="754" alt="Screenshot 2024-07-11 at 15 18 08" src="https://github.com/marcomaida/claycode/assets/28363981/3eeffd90-8530-4781-867a-708f7f8f2aba">

