### PR TITLE
Add consistent footprint metric in packer and on screen

### DIFF
--- a/generator/packer/pack.js
+++ b/generator/packer/pack.js
@@ -26,7 +26,7 @@ export function packClaycode(tree, polygon) {
             nodePaddingMin,
             tries / MAX_TRIES
         );
-        tree.compute_weights(padding);
+        tree.compute_footprints(padding);
         let minNodeArea = area(polygon) * 0.0002;
 
         try {
@@ -70,8 +70,8 @@ function packClaycodeIteration(
     /* 
      * Finally, partition the node and recursively call the function
      */
-    const weights = Math.normalise(node.children.map((c) => c.weight));
-    const partition = partitionPolygon(subPolygon, weights);
+    const footprints = Math.normalise(node.children.map((c) => c.footprint));
+    const partition = partitionPolygon(subPolygon, footprints);
     console.assert(partition.length == node.children.length);
     for (const [i, c] of node.children.entries()) {
         if (!packClaycodeIteration(

--- a/generator/scenes/scene_tree_generator.js
+++ b/generator/scenes/scene_tree_generator.js
@@ -54,10 +54,10 @@ function generateRandomTree(
     return remainingNodes;
   }
 
-  const inner = new TreeNode(null, []);
-  _gen(inner, maxChildren, maxHeight, growProbability, 1, remainingNodes - 2);
-
-  return new Tree(new TreeNode(null, [inner]));
+  const root = new TreeNode(null, []);
+  _gen(root, maxChildren, maxHeight, growProbability, 1, remainingNodes - 2);
+  console.log(root.children.length);
+  return new Tree(root);
 }
 
 function polygonView() {

--- a/generator/scenes/utils.js
+++ b/generator/scenes/utils.js
@@ -52,10 +52,10 @@ export function updateInfoText(inputText, currentTree, infoSuffix = "") {
   if (inputText !== null)
     infoText.textContent =
       `${inputText.length} Chars | ${textToBits(inputText).length} bits | ${currentTree.root.numDescendants
-      } Nodes ` + infoSuffix;
+      } Nodes | Footprint: ${currentTree.get_total_footprint()} ` + infoSuffix;
   else
     infoText.textContent =
-      `${currentTree.root.numDescendants} Nodes` + infoSuffix;
+      `${currentTree.root.numDescendants} Nodes | Footprint: ${currentTree.get_total_footprint()}` + infoSuffix;
 }
 
 // Helper function to avoid too many calls to the drawing function

--- a/generator/tree/tree.js
+++ b/generator/tree/tree.js
@@ -7,7 +7,7 @@ export class Tree {
     this.maxDepth = 0;
 
     this.initialize_nodes(this.root, "X", 0);
-    this.compute_weights(1);
+    this.compute_footprints(1);
     this.compute_depth(0);
   }
 
@@ -43,44 +43,31 @@ export class Tree {
     this.maxDepth = Math.max(this.maxDepth, depth);
   }
 
-  compute_weights(node_padding) {
-    compute_weights_(this.root, node_padding);
+  compute_footprints(node_padding) {
+    compute_footprints_(this.root, node_padding);
   }
 
   compute_depth(node_depth) {
     compute_depth_(this.root, node_depth);
   }
+
+  get_total_footprint() {
+    let total_fp = 0;
+    for (const node of treeIterator(this)) {
+      total_fp += node.footprint;
+    }
+    return total_fp;
+  }
 }
 
-function compute_weights_(node, node_padding) {
-  let children_weight = 0;
+function compute_footprints_(node, node_padding) {
+  let children_footprint = 0;
   for (const c of node.children) {
-    compute_weights_(c, node_padding);
-    children_weight += c.weight;
+    compute_footprints_(c, node_padding);
+    children_footprint += c.footprint;
   }
 
-  /* 
-     WEIGHT HEURISTIC
-     This heuristic tries to approximate how much space a node 
-     will take in a Claycode drawing. 
-
-     This heuristic assumes an ideal space distribution of the 
-     children, i.e., it assumes that the children are arranged
-     so that they form a perfect circle, which must be padded.
-             ___
-           /    p\    `O` is the area occupied by the children, 
-          |   O---|   while `p` is the padding to add to compute
-           \ ___ /    the parent's node area.
-
-  // const children_r = Math.sqrt(children_weight / Math.PI);
-  // const father_r = children_r + node_padding;
-  // node.weight = Math.pow(father_r, 2) * Math.PI;
-     
-    Not working well so I went back to basic +1 heuristic 
-  */
-
-  node.weight = children_weight + node_padding;
-  node.weight = Math.max(node.weight, 1);
+  node.footprint = children_footprint + 1;
 }
 
 function compute_depth_(node, node_depth) {

--- a/generator/tree/tree_node.js
+++ b/generator/tree/tree_node.js
@@ -14,7 +14,7 @@ export class TreeNode {
     /* Describes how much space is taken by this node, considering
        also all its descendants. The UoM is irrelevant, as long as
        all nodes are weighted using the same heuristics. */
-    this.weight = null;
+    this.footprint = null;
 
     /* Root is at depth zero. Other nodes have depth parent+1  */
     this.depth = null;

--- a/generator/tree/util.js
+++ b/generator/tree/util.js
@@ -12,7 +12,7 @@ export function duplicateTreeNTimes(tree, N) {
         const newNode = new TreeNode(null, []);
         newNode.label = node.label;
         newNode.numDescendants = node.numDescendants;
-        newNode.weight = node.weight;
+        newNode.footprint = node.footprint;
 
         for (const child of node.children) {
             const newChild = cloneNode(child);
@@ -44,7 +44,7 @@ export function duplicateTreeNTimes(tree, N) {
     // Initialize the new tree
     const newTree = new Tree(newRoot);
     newTree.initialize_nodes(newRoot, "X", 0);
-    newTree.compute_weights(1);
+    newTree.compute_footprints(1);
 
     return newTree;
 }
@@ -81,7 +81,7 @@ export function generateRandomTree(N) {
     // Initialize the tree
     const tree = new Tree(root);
     tree.initialize_nodes(root, "X", 0);
-    tree.compute_weights(1);
+    tree.compute_footprints(1);
 
     return tree;
 }


### PR DESCRIPTION
In the paper, we formally defined the footprint metric as the number of descendants of a node +1
 

With this PR:

- We show total footprint of a tree (i.e., sum of the footprints of all nodes) on screen in demos
- Use the footprint to compute the packer's weights
