### PR TITLE
Improved stylized claycode generation

### DIFF
--- a/generator/image_processing/contour.js
+++ b/generator/image_processing/contour.js
@@ -179,7 +179,7 @@ export function computeContourPolygons(binaryImage, center, size) {
     binaryImage = addPadding(binaryImage);
     binaryImage = markContours(binaryImage);
     let polygons = extractPolygonsFromContours(binaryImage);
-    polygons = polygons.map((poly) => simplify(poly, 3, false));
+    polygons = polygons.map((poly) => simplify(poly, 1, false));
     let pixiPolygons = posArraysToPixiVecArrays(polygons, center, size);
 
     return pixiPolygons;

--- a/generator/packer/packer_brush.js
+++ b/generator/packer/packer_brush.js
@@ -1,5 +1,5 @@
 import { drawPolygon } from "./draw.js";
-import { area, matchPolygonsCentroids } from "../geometry/geometry.js";
+import { area, circularity, matchPolygonsCentroids } from "../geometry/geometry.js";
 import { createStarPolygon, createMouseHeadPolygon, createCirclePolygon, createUPolygon } from "../geometry/shapes.js";
 
 export class PackerBrush {
@@ -51,6 +51,7 @@ export class PackerBrush {
         let color = this.leafColors[(node.depth + 1) % 2]
         let shape = this.leafShapes[(node.depth) % 2]
         let originalPolygon = node.getPolygon();
+        let circ_root = Math.sqrt(circularity(originalPolygon)); // Heuristic to decide dimension of custom polygon
         let customPolygon = null;
         let baseRadius = Math.sqrt(area(originalPolygon) / Math.PI);
         switch (shape) {
@@ -58,21 +59,21 @@ export class PackerBrush {
                 customPolygon = originalPolygon;
                 break;
             case PackerBrush.Shape.SQUARE:
-                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), 0.8 * baseRadius, 4, new PIXI.Vec(1, 1), 45)
+                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 4, new PIXI.Vec(1, 1), 45)
                 break;
             case PackerBrush.Shape.CIRCLE:
-                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), 0.8 * baseRadius, 10)
+                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 10)
                 break;
             case PackerBrush.Shape.MOUSE:
-                customPolygon = createMouseHeadPolygon(new PIXI.Vec(0, 0), 0.5 * baseRadius)
+                customPolygon = createMouseHeadPolygon(new PIXI.Vec(0, 0), circ_root / 2 * baseRadius)
                 break;
             case PackerBrush.Shape.STAR:
-                customPolygon = createStarPolygon(new PIXI.Vec(0, 0), 0.7 * baseRadius, 5);
+                customPolygon = createStarPolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 5);
                 break;
             case PackerBrush.Shape.U:
                 const u = 0.8 * baseRadius;
                 const thickness = u / 3;
-                customPolygon = createUPolygon(new PIXI.Vec(0, 0), u, u * 1.8, thickness, thickness);
+                customPolygon = createUPolygon(new PIXI.Vec(0, 0), u, u * 1.8 * circ_root, thickness, thickness);
                 break;
             default:
                 throw "Unsupported leaf shape requested";


### PR DESCRIPTION
- Improve leaf polygon sizing choices, by considering the original polygon's circularity
- Less simplification of shapes. Packing time is still acceptable, and results are way more visually appealing

<img width="1217" alt="Screenshot 2025-01-10 at 20 06 52" src="https://github.com/user-attachments/assets/49c2182c-2372-45b2-9756-6b5beb6f24d9" />
