### PR TITLE
Tweak circularity-based size dimension heuristics

### DIFF
--- a/generator/packer/packer_brush.js
+++ b/generator/packer/packer_brush.js
@@ -51,7 +51,7 @@ export class PackerBrush {
         let color = this.leafColors[(node.depth + 1) % 2]
         let shape = this.leafShapes[(node.depth) % 2]
         let originalPolygon = node.getPolygon();
-        let circ_root = Math.sqrt(circularity(originalPolygon)); // Heuristic to decide dimension of custom polygon
+        let circ = circularity(originalPolygon); // Heuristic to decide dimension of custom polygon
         let customPolygon = null;
         let baseRadius = Math.sqrt(area(originalPolygon) / Math.PI);
         switch (shape) {
@@ -59,21 +59,21 @@ export class PackerBrush {
                 customPolygon = originalPolygon;
                 break;
             case PackerBrush.Shape.SQUARE:
-                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 4, new PIXI.Vec(1, 1), 45)
+                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ * baseRadius, 4, new PIXI.Vec(1, 1), 45)
                 break;
             case PackerBrush.Shape.CIRCLE:
-                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 10)
+                customPolygon = createCirclePolygon(new PIXI.Vec(0, 0), circ * baseRadius, 10)
                 break;
             case PackerBrush.Shape.MOUSE:
-                customPolygon = createMouseHeadPolygon(new PIXI.Vec(0, 0), circ_root / 2 * baseRadius)
+                customPolygon = createMouseHeadPolygon(new PIXI.Vec(0, 0), circ / 2 * baseRadius)
                 break;
             case PackerBrush.Shape.STAR:
-                customPolygon = createStarPolygon(new PIXI.Vec(0, 0), circ_root * baseRadius, 5);
+                customPolygon = createStarPolygon(new PIXI.Vec(0, 0), circ * baseRadius, 5);
                 break;
             case PackerBrush.Shape.U:
                 const u = 0.8 * baseRadius;
                 const thickness = u / 3;
-                customPolygon = createUPolygon(new PIXI.Vec(0, 0), u, u * 1.8 * circ_root, thickness, thickness);
+                customPolygon = createUPolygon(new PIXI.Vec(0, 0), u, u * 1.8 * circ, thickness, thickness);
                 break;
             default:
                 throw "Unsupported leaf shape requested";


### PR DESCRIPTION
Removing the `sqrt` part, as it creates too-large leaves sometimes