### PR TITLE
Improve performance of fragments in encoding-based Claycodes

### DIFF
--- a/generator/scenes/scene_fragment.js
+++ b/generator/scenes/scene_fragment.js
@@ -18,7 +18,7 @@ function polygonView() {
 
   let current_tree = Tree.fromString(inputTreeTopology.value)
   if (!current_tree) {
-    inputTreeTopology.value = generateRandomTree(inputNumNodes.value).toString();
+    inputTreeTopology.value = generateRandomTree(inputNumNodes.value, true).toString();
     current_tree = Tree.fromString(inputTreeTopology.value)
     if (!current_tree) {
       throw `current tree cannot be null after the tree was generated`;

--- a/generator/scenes/scene_image_fragment.js
+++ b/generator/scenes/scene_image_fragment.js
@@ -178,7 +178,7 @@ function imagePolygonView(useLastTrees = false) {
     //****  Get tree
     let current_tree = Tree.fromString(inputTreeTopology.value)
     if (!current_tree) {
-      inputTreeTopology.value = generateRandomTree(inputNumNodes.value).toString();
+      inputTreeTopology.value = generateRandomTree(inputNumNodes.value, true).toString();
       current_tree = Tree.fromString(inputTreeTopology.value)
       if (!current_tree) {
         throw `current tree cannot be null after the tree was generated`;

--- a/generator/tree/util.js
+++ b/generator/tree/util.js
@@ -25,20 +25,8 @@ export function duplicateTreeNTimes(tree, N) {
 
     // Duplicate the original tree N times and add to the new root
     for (let i = 0; i < N; i++) {
-        // Clone tree
         const clonedTree = cloneNode(tree.root);
-
-        if (N > 1) {
-            // Add an intermediate node to make a 2-tower
-            const frameNode = new TreeNode(newRoot, [clonedTree]);
-            clonedTree.father = frameNode;
-            newRoot.children.push(frameNode);
-        }
-        else {
-            // In the N=1 case, we do not need to make a 2-tower; it is
-            // done automatically as there is only 1 child
-            newRoot.children.push(clonedTree);
-        }
+        newRoot.children.push(clonedTree);
     }
 
     // Initialize the new tree
@@ -53,7 +41,9 @@ export function duplicateTreeNTimes(tree, N) {
 // The generation is biased so that trees are large and not tall.
 // A root is created. Then, for each iteration, a random existing node is chosen and a 
 // child is added to it. Naturally, this will bias towards short trees.
-export function generateRandomTree(N) {
+// If `with_extra_root` is true, generates an intermediate node. This is necessary
+// as some application of Claycode require the root to be a "two tower"
+export function generateRandomTree(N, with_extra_root = false) {
     const MIN_LEVEL_1_CHILDREN = 3;
 
     if (N <= 0) return null;
@@ -65,7 +55,18 @@ export function generateRandomTree(N) {
 
     // Create the root node
     const root = createNode();
-    let nodes = [root];
+
+    // Handle eventual extra root
+    let nodes;
+    if (with_extra_root) {
+        const inner_root = createNode(root);
+        root.children.push(inner_root);
+        nodes = [inner_root];
+    }
+    else {
+        nodes = [root];
+    }
+
     for (let n = 0; n < N; n++) {
         // pick a random node, add a child. 
         // This over-represents lower-level nodes, leading to trees that are wider


### PR DESCRIPTION
The generator creates an extra border around each fragment that is useless in encoding-based Claycodes (while it is useful in fragment-based Claycodes). 


This PR fixes it. 
Now we have more space available. E.g., take this image with 4 fragments. It encodes the same exact Claycode. 
Left is before the fix, right is after.

<img width="1101" alt="Screenshot 2025-04-05 at 12 57 15" src="https://github.com/user-attachments/assets/0fa35e57-fd93-4edd-a674-611701fc6f74" />
