### PR TITLE
Improve generator website

### DIFF
--- a/generator/geometry/polygon_partition.js
+++ b/generator/geometry/polygon_partition.js
@@ -97,7 +97,7 @@ export function splitPolygonInSimplestPartition(
     }
 
     tries_without_improvement += 1;
-    if (tries_without_improvement >= MAX_TRIES_WITHOUT_IMPROVEMENT) {
+    if (best_partition != null && tries_without_improvement >= MAX_TRIES_WITHOUT_IMPROVEMENT) {
       break;
     }
   }

--- a/generator/packer/draw.js
+++ b/generator/packer/draw.js
@@ -19,6 +19,12 @@ export function drawPolygon(points, color = DEFAULT_COLOR) {
   graphics.endFill();
 }
 
+export function drawPolygonVertices(points, radius = 5, color = DEFAULT_COLOR) {
+  points.forEach((point) => {
+    drawCircle(point, radius, color);
+  });
+}
+
 export function drawRoundedRect(
   x,
   y,

--- a/generator/packer/pack.js
+++ b/generator/packer/pack.js
@@ -17,7 +17,7 @@ export function packClaycode(tree, polygon) {
         Math.min(tree.root.numDescendants, 700) / 700
     );
 
-    const MAX_TRIES = 100;
+    const MAX_TRIES = 60;
     let tries = 0;
     while (tries < MAX_TRIES) {
         // Decrease padding if it keeps failing
@@ -54,8 +54,9 @@ function packClaycodeIteration(
 ) {
     /* 
      * Do first padding phase
+     * In the case of the root, we double the padding, to make it consistent.
      */
-    const subPolygon = padPolygon(polygon, padding / 2);
+    const subPolygon = padPolygon(polygon, node.isRoot() ? padding : padding / 2);
     if (subPolygon === null) {
         return false;
     }

--- a/generator/scenes/utils.js
+++ b/generator/scenes/utils.js
@@ -1,9 +1,8 @@
 import { textToBits } from "../conversion/convert.js";
-import { clearDrawing, initDrawing } from "../packer/draw.js";
-import { area } from "../geometry/geometry.js";
+import { drawPolygonVertices, initDrawing } from "../packer/draw.js";
 import { drawClaycode } from "../packer/draw_polygon_claycode.js";
 import { DefaultBrush, PackerBrush } from "../packer/packer_brush.js";
-import { createMouseHeadPolygon, createCirclePolygon } from "../geometry/shapes.js";
+import { createMouseHeadPolygon, createCirclePolygon, createHeartPolygon, createStarPolygon, createUPolygon, createSpiralPolygon } from "../geometry/shapes.js";
 import { TreeNode } from "../tree/tree_node.js";
 import { packClaycode } from "../packer/pack.js";
 
@@ -75,27 +74,25 @@ export async function showChangeShapeLabel(isVisible, message = "Change Shape") 
 
 // Shape management
 export const POLYGON_SHAPES = [
-  // [num_edges, scale, rotation_deg]
-  [4, new PIXI.Vec(1, 1), 45],
-  [50, new PIXI.Vec(1, 1), 0],
-  [3, new PIXI.Vec(1, 1), 0],
-  [4, new PIXI.Vec(1.5, 0.7), 45],
-  [8, new PIXI.Vec(1, 1), 0],
+  (center, size) => createCirclePolygon(center, size, 4, new PIXI.Vec(1, 1), 45),
+  (center, size) => createCirclePolygon(center, size, 50, new PIXI.Vec(1, 1), 0),
+  (center, size) => createCirclePolygon(center, size, 3, new PIXI.Vec(1, 1), 0),
+  (center, size) => createCirclePolygon(center, size, 4, new PIXI.Vec(1.5, 0.7), 45),
+  (center, size) => createHeartPolygon(center, size, 70),
+  (center, size) => createMouseHeadPolygon(center, size / 2, 30),
+  (center, size) => createStarPolygon(center, size, 5),
+  (center, size) => createSpiralPolygon(center, size, 3, 70, 0.05, 0.15, 0.5),
 ];
 export function getPolygonOfIndex(index, polygonCenter, polygonSize) {
-  return createCirclePolygon(
-    polygonCenter,
-    polygonSize,
-    POLYGON_SHAPES[index][0],
-    POLYGON_SHAPES[index][1],
-    POLYGON_SHAPES[index][2]
-  );
+  return POLYGON_SHAPES[index](polygonCenter, polygonSize);
 }
 
 export function drawPolygonClaycode(
   current_tree,
   polygon
 ) {
+  // Uncomment to see the polygon's vertices
+  // drawPolygonVertices(polygon);
   if (packClaycode(current_tree, polygon)) {
     let brush = new DefaultBrush();
     drawClaycode(current_tree, polygon, brush)

--- a/generator/tree/tree_node.js
+++ b/generator/tree/tree_node.js
@@ -43,6 +43,10 @@ export class TreeNode {
     return this.children.length === 0;
   }
 
+  isRoot() {
+    return this.father === null;
+  }
+
   setPolygon(polygon) {
     this.polygon = polygon;
   }


### PR DESCRIPTION
This PR introduces a series of improvements needed for SIGGRAPH's trailer

- New Claycode shapes
- Change generator to be able to generate any shape defined in `shapes.js`
- Improve packer's response time by tuning tries and padding function
- Fixed missing double padding for root node in packer (border was too thin)

