### PR TITLE
Fix wrong image path in fragment image scene

### DIFF
--- a/generator/scenes/scene_image_fragment.js
+++ b/generator/scenes/scene_image_fragment.js
@@ -141,7 +141,7 @@ function distributeFragments(polygons, targetNumFragments, minAreaPerc) {
 }
 
 // Debug default picture
-let imageUrl = `${window.location.origin}/images/simplifiedpug.png`
+let imageUrl = `${window.location.origin}/images/astronaut.png`
 PIXI.Loader.shared.add(imageUrl).load(async (loader, resources) => {
   let texture = PIXI.Texture.from(resources[imageUrl].url);
   await loadImage(texture)


### PR DESCRIPTION
The path was not updated properly. This PR fixes it.