### PR TITLE
Host website in the local network

### DIFF
--- a/webapp/Makefile
+++ b/webapp/Makefile
@@ -1,7 +1,7 @@
 default: macos
 
 macos:
-	(sleep 1 && open http://localhost:731/index.html) & (python3 -m http.server 731)
+	(sleep 1 && open http://localhost:731/index.html) & (python3 -m http.server 731 --bind 0.0.0.0)
 
 linux:
 	sudo python3 -m http.server 731 &


### PR DESCRIPTION
This allows for quick debugging from the phone, by connecting to the host locally 