### PR TITLE
Add resilience to small polygons in find contours

### DIFF
--- a/webapp/image_processing/contour.js
+++ b/webapp/image_processing/contour.js
@@ -6,12 +6,8 @@
  * SPDX-License-Identifier: MIT AND Commons-Clause
  */
 
-// Given a binary image, computes a set of non-overlapping polygons that covers the image.
-// `size` specifies the size of the image in PIXI's coordinate system.
-//
-// Returns an array of arrays of PIXI.Vec point. Each array represents a polygon.
-
-import { closeSmallIslands } from "./util.js";
+import { closeSmallIslands, closeSmallEmptyGaps } from "./util.js";
+import { area } from "../geometry/geometry.js";
 import "./simplify.js"
 
 const EMPTY = 0;
@@ -168,6 +164,10 @@ function posArraysToPixiVecArrays(polygons, center, size) {
 }
 
 /*
+    Given a binary image, computes a set of non-overlapping polygons that covers the image.
+    `size` specifies the size of the image in PIXI's coordinate system.
+    Returns an array of arrays of PIXI.Vec point. Each array represents a polygon.
+    
     INPUT
     [0, 0, 0],
     [0, 0, 0],
@@ -183,12 +183,22 @@ function posArraysToPixiVecArrays(polygons, center, size) {
     [1, 1, 1, 1, 1],
 */
 export function computeContourPolygons(binaryImage, center, size) {
-    binaryImage = closeSmallIslands(binaryImage, 0.01);
+    // Remove noise (small islands of "1"s)
+    binaryImage = closeSmallIslands(binaryImage, 0.01, 1);
+    // Close small gaps in the contours, effectively padding
+    binaryImage = closeSmallEmptyGaps(binaryImage);
+    // Remove negative noise (small islands of "0"s) - these could lead to very small polygons
+    binaryImage = closeSmallIslands(binaryImage, 0.02, 0);
     binaryImage = addPadding(binaryImage);
     binaryImage = markContours(binaryImage);
     let polygons = extractPolygonsFromContours(binaryImage);
     polygons = polygons.map((poly) => simplify(poly, 1, false));
     let pixiPolygons = posArraysToPixiVecArrays(polygons, center, size);
 
+    // Last safety measure: filter out polygons with a very small area
+    const totalImageArea = binaryImage.length * binaryImage[0].length;
+    const minAreaPerc = 0.01;
+    const minPolygonArea = totalImageArea * minAreaPerc;
+    pixiPolygons = pixiPolygons.filter(poly => area(poly) >= minPolygonArea);
     return pixiPolygons;
 }

--- a/webapp/image_processing/util.js
+++ b/webapp/image_processing/util.js
@@ -6,15 +6,52 @@
  * SPDX-License-Identifier: MIT AND Commons-Clause
  */
 
+// Slides a 3x3 kernel over the image.
+// If there are both zeroes and ones in the kernel, set all pixels in the kernel to one.
+export function closeSmallEmptyGaps(binaryImage) {
+    const height = binaryImage.length;
+    const width = binaryImage[0].length;
+    // Copy the image to avoid modifying in place during scan
+    const result = binaryImage.map(row => row.slice());
+    for (let y = 0; y < height - 2; y++) {
+        for (let x = 0; x < width - 2; x++) {
+            let hasZero = false;
+            let hasOne = false;
+            // Scan 3x3 kernel
+            for (let dy = 0; dy < 3; dy++) {
+                for (let dx = 0; dx < 3; dx++) {
+                    const val = binaryImage[y + dy][x + dx];
+                    if (val === 0) hasZero = true;
+                    if (val === 1) hasOne = true;
+                }
+            }
+            if (hasZero && hasOne) {
+                // Set all to one in result
+                for (let dy = 0; dy < 3; dy++) {
+                    for (let dx = 0; dx < 3; dx++) {
+                        result[y + dy][x + dx] = 1;
+                    }
+                }
+            }
+        }
+    }
+    return result;
+}
+
 // Given a binary image, delete each isolated group of pixels whose area is
 // less than `island_percentage_threshold` of the total image area.
 // Writes the result back to the binary binaryImage.
-export function closeSmallIslands(binaryImage, island_percentage_threshold) {
+export function closeSmallIslands(binaryImage, island_percentage_threshold, island_pixel_value) {
+    if (island_pixel_value !== 0 && island_pixel_value !== 1) {
+        throw new Error("island_pixel_value must be either 0 or 1");
+    }
     const width = binaryImage[0].length;
     const height = binaryImage.length;
     const visited = new Uint8Array(width * height);
     const threshold = (width * height) * island_percentage_threshold;
     const islands = [];
+    const targetValue = island_pixel_value;
+    const fillValue = targetValue === 1 ? 0 : 1;
 
     // Function to perform flood fill and collect island pixels
     function floodFill(x, y) {
@@ -26,7 +63,7 @@ export function closeSmallIslands(binaryImage, island_percentage_threshold) {
             const [cx, cy] = stack.pop();
             idx = cy * width + cx;
 
-            if (cx < 0 || cy < 0 || cx >= width || cy >= height || visited[idx] || binaryImage[cy][cx] === 0) {
+            if (cx < 0 || cy < 0 || cx >= width || cy >= height || visited[idx] || binaryImage[cy][cx] !== targetValue) {
                 continue;
             }
 
@@ -45,7 +82,7 @@ export function closeSmallIslands(binaryImage, island_percentage_threshold) {
     // Find all islands
     for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
-            if (binaryImage[y][x] === 1 && !visited[y * width + x]) {
+            if (binaryImage[y][x] === targetValue && !visited[y * width + x]) {
                 const island = floodFill(x, y);
                 islands.push(island);
             }
@@ -53,11 +90,16 @@ export function closeSmallIslands(binaryImage, island_percentage_threshold) {
     }
 
     // Remove small islands
+    let removedCount = 0;
+    let keptCount = 0;
     for (const island of islands) {
         if (island.length < threshold) {
             for (const [x, y] of island) {
-                binaryImage[y][x] = 0;
+                binaryImage[y][x] = fillValue;
             }
+            removedCount++;
+        } else {
+            keptCount++;
         }
     }
 

--- a/webapp/image_processing/util.js
+++ b/webapp/image_processing/util.js
@@ -90,16 +90,11 @@ export function closeSmallIslands(binaryImage, island_percentage_threshold, isla
     }
 
     // Remove small islands
-    let removedCount = 0;
-    let keptCount = 0;
     for (const island of islands) {
         if (island.length < threshold) {
             for (const [x, y] of island) {
                 binaryImage[y][x] = fillValue;
             }
-            removedCount++;
-        } else {
-            keptCount++;
         }
     }
 


### PR DESCRIPTION
Sometimes, very small polygons are created from the small empty spaces of the image (see below). The packer fails when trying to pack claycodes in such small polygons. To fix this, the PR modifies `findContours` to avoid creating small polygons as follows:
* Pad the borders of the non-alpha pixels to close very small gaps
* If very small empty islands are left, fill them to avoid creating polygons
* If small polygons were created nonetheless, filter them out based on their area

<img width="605" height="606" alt="image" src="https://github.com/user-attachments/assets/f07c7f4a-3378-4387-9a15-2e964c9d7531" />
<img width="69" height="63" alt="image" src="https://github.com/user-attachments/assets/6e453810-03cb-4ef9-add5-65c28a1f85fb" />
<img width="1022" height="938" alt="image" src="https://github.com/user-attachments/assets/bb1579b9-bc2c-4523-a0da-edb5fb351ffd" />
