### PR TITLE
Fix header overlapment issues

### DIFF
--- a/webapp/common/header.css
+++ b/webapp/common/header.css
@@ -87,15 +87,15 @@
 
 /* Media queries */
 @media (max-width: 480px) {
+  .header-nav {
+    display: none;
+  }
+  
   .gheader h1 {
     font-size: 16px;
   }
   
   .gimage img {
     width: 28px;
-  }
-  
-  .header-link {
-    font-size: 14px;
   }
 }

--- a/webapp/scan/index.html
+++ b/webapp/scan/index.html
@@ -40,8 +40,8 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            width: min(90vw, 90vh);
-            height: min(90vw, 90vh);
+            width: min(60vw, 60vh);
+            height: min(60vw, 60vh);
             border: 3px solid rgba(240, 240, 240, 0.25);
             border-radius: 16px;
             pointer-events: none;
@@ -62,26 +62,25 @@
         #fps-counter {
             position: absolute;
             top: 10px;
-            right: 15px;
+            right: 10px;
             background: rgba(0, 0, 0, 0.8);
             color: white;
-            padding: 8px 12px;
+            padding: 6px 8px;
             border-radius: 4px;
-            font-size: 14px;
-            display: inline-block;
+            font-size: 12px;
+            z-index: 10;
         }
 
         #resolution-label {
             position: absolute;
-            top: 10px;
-            right: 100px;
+            top: 50px;
+            right: 10px;
             background: rgba(0, 0, 0, 0.8);
             color: white;
-            padding: 8px 12px;
+            padding: 6px 8px;
             border-radius: 4px;
-            font-size: 14px;
+            font-size: 12px;
             z-index: 10;
-            display: inline-block;
         }
 
         #result-modal {
@@ -135,6 +134,28 @@
             font-size: 18px;
             text-align: center;
         }
+
+        @media (max-width: 480px) {
+            #fps-counter, #resolution-label {
+                font-size: 10px;
+                padding: 4px 6px;
+            }
+            
+            #toggle-processed-view {
+                font-size: 10px !important;
+                padding: 4px 6px !important;
+            }
+            
+            #target-square {
+                width: min(85vw, 85vh);
+                height: min(85vw, 85vh);
+            }
+            
+            #info-box {
+                font-size: 14px;
+                padding: 12px;
+            }
+        }
     </style>
 </head>
 
@@ -154,7 +175,7 @@
         <div id="info-box">Touch to scan...</div>
 
         <button id="toggle-processed-view"
-            style="position:absolute;top:10px;left:15px;z-index:10;padding:8px 12px;border-radius:4px;border:none;background:#222;color:#fff;cursor:pointer;">
+            style="position:absolute;top:10px;left:10px;z-index:10;padding:6px 8px;border-radius:4px;border:none;background:#222;color:#fff;cursor:pointer;font-size:12px;">
             Show Processed View
         </button>
         <canvas id="processed-canvas"


### PR DESCRIPTION
This PR solves the following issues:
- Header overlapments for the target-square
- Limits header size on mobile devices (< 480px)
- Fixes elements positioning by with 10px margins 